### PR TITLE
use explicit definition for `isConsonant`

### DIFF
--- a/NLP/Minimorph/English.hs
+++ b/NLP/Minimorph/English.hs
@@ -274,4 +274,4 @@ isLetterWithInitialVowelSound = (`elem` ("aeiofhlmnrsx" :: String)) . toLower
 
 -- | Is a consonant.
 isConsonant :: Char -> Bool
-isConsonant = not . isVowel
+isConsonant = (`elem` ("bcdfghjklmnpqrstvwxyz" :: String)) . toLower

--- a/NLP/Minimorph/English.hs
+++ b/NLP/Minimorph/English.hs
@@ -273,5 +273,8 @@ isLetterWithInitialVowelSound :: Char -> Bool
 isLetterWithInitialVowelSound = (`elem` ("aeiofhlmnrsx" :: String)) . toLower
 
 -- | Is a consonant.
+--
+--   Note that not every `Char` is either a vowel or a consonant.
+--   We consider numbers, spaces and symbols to be neither vowel or consonants
 isConsonant :: Char -> Bool
 isConsonant = (`elem` ("bcdfghjklmnpqrstvwxyz" :: String)) . toLower

--- a/test/NLP/Minimorph/EnglishTest.hs
+++ b/test/NLP/Minimorph/EnglishTest.hs
@@ -127,6 +127,7 @@ nouns =
     , noun "thesis" "theses"
     , noun "elf"    "elves"
     , noun "ace"    "aces"
+    , noun "5y"     "5ys"
     ]
   where
     noun s p = (s,p)


### PR DESCRIPTION
this avoids false positives on numbers and symbols

closes #1 